### PR TITLE
Disable the internal pullups after i2c initialization

### DIFF
--- a/radiono.ino
+++ b/radiono.ino
@@ -314,6 +314,9 @@ void setup() {
   printLine1("Raduino v0.02 "); 
 
   Wire.begin();
+  // Disable internal pullups
+  digitalWrite(SDA, 0);
+  digitalWrite(SCL, 0);
 
   // Force Si570 to reset to initial freq
   i2c_write(si570_i2c_address,135,0x01);


### PR DESCRIPTION
You can disable the pull request after initialization of the i2c module. 

The line does go a little bit above the 3.3v rail for less than 10 micro second before the first i2c packet. I doubt this would damage the si570. Even without this change, the line never goes to +5v. The 3.3v pull up resistor acts as a pull-down against the 20k internal pullup and I have measured 3.42 v max with the internal pullups on.
