### PR TITLE
Refactor si570 + Automatically calibrate the module + Detect errors

### DIFF
--- a/Si570.cpp
+++ b/Si570.cpp
@@ -1,0 +1,224 @@
+/*
+ * Si570 Library for Arduino
+ *
+ * MIT License
+ *
+ * Copyright Thomas Sarlandie - 2014
+ * Based on previous work by Ashar Farhan
+ */
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "Si570.h"
+
+#define FREQ_XTAL (114292532l)
+
+Si570::Si570(char si570_address) {
+  i2c_address = si570_address;
+
+  Wire.begin();
+
+  // Disable internal pullups - You will need external 3.3v pullups.
+  digitalWrite(SDA, 0);
+  digitalWrite(SCL, 0);
+
+  f_center = 0;
+  frequency = 0;
+  // TODO: make that configurable
+  freq_xtal = FREQ_XTAL;
+  // Force Si570 to reset to initial freq
+  i2c_write(135,0x01);
+  delay(20);
+  read_si570();
+}
+
+void Si570::i2c_write(char reg_address, char data) {
+  int rdata = data;
+  Wire.beginTransmission(this->i2c_address);
+  Wire.write(reg_address);
+  Wire.write(rdata);
+  Wire.endTransmission();
+}
+
+char Si570::i2c_read(int reg_address) {
+  unsigned char rdata = 0xFF;
+  Wire.beginTransmission(this->i2c_address);
+  Wire.write(reg_address);
+  Wire.endTransmission();
+  Wire.requestFrom(this->i2c_address,1);
+  if (Wire.available()) rdata = Wire.read();
+  return rdata;
+}
+
+void Si570::read_si570(){
+  //we have to read eight consecutive registers starting at register 5
+  for (int i = 7; i <= 12; i++)
+    this->dco_reg[i] = i2c_read(i);
+}
+
+void Si570::write_si570()
+{
+  int idco, i;
+
+  // Freeze DCO
+  idco = i2c_read(137);
+  i2c_write(137, idco | 0x10 );
+
+  i2c_write(7, this->dco_reg[7]);
+
+  //Set Registers
+  for( i=7; i <= 12; i++){
+    i2c_write(i, this->dco_reg[i]);
+    idco = i2c_read(i);
+  }
+
+  // Unfreeze DCO
+  idco = i2c_read(137);
+  i2c_write (137, idco & 0xEF );
+
+  // Set new freq
+  i2c_write(135,0x40);
+}
+
+void Si570::qwrite_si570()
+{
+  int i, idco;
+  //Set Registers
+  for( i=8; i <= 12; i++){
+    i2c_write(i, this->dco_reg[i]);
+    idco = i2c_read(i);
+  }
+}
+
+void Si570::setBitvals(void){
+  //set the rfreq values for each bit of the rfreq (integral)
+  bitval[28] = (this->freq_xtal) / (hs * n1);
+  bitval[29] = bitval[28] << 1;
+  bitval[30] = bitval[29] << 1;
+  bitval[31] = bitval[30] << 1;
+  bitval[32] = bitval[31] << 1;
+  bitval[33] = bitval[32] << 1;
+  bitval[34] = bitval[33] << 1;
+  bitval[35] = bitval[34] << 1;
+  bitval[36] = bitval[35] << 1;
+  bitval[37] = bitval[36] << 1;
+
+  //set the rfreq values for each bit of the rfreq (integral)
+  bitval[27] = bitval[28] >> 1;
+  bitval[26] = bitval[27] >> 1;
+  bitval[25] = bitval[26] >> 1;
+  bitval[24] = bitval[25] >> 1;
+  bitval[23] = bitval[24] >> 1;
+  bitval[22] = bitval[23] >> 1;
+  bitval[21] = bitval[22] >> 1;
+  bitval[20] = bitval[21] >> 1;
+  bitval[19] = bitval[20] >> 1;
+  bitval[18] = bitval[19] >> 1;
+  bitval[17] = bitval[18] >> 1;
+  bitval[16] = bitval[17] >> 1;
+  bitval[15] = bitval[16] >> 1;
+  bitval[14] = bitval[15] >> 1;
+  bitval[13] = bitval[14] >> 1;
+  bitval[12] = bitval[13] >> 1;
+  bitval[11] = bitval[12] >> 1;
+  bitval[10] = bitval[11] >> 1;
+  bitval[9] = bitval[10] >> 1;
+  bitval[8] = bitval[9] >> 1;
+  bitval[7] = bitval[8] >> 1;
+  bitval[6] = bitval[7] >> 1;
+  bitval[5] = bitval[6] >> 1;
+  bitval[4] = bitval[5] >> 1;
+  bitval[3] = bitval[4] >> 1;
+  bitval[2] = bitval[3] >> 1;
+  bitval[1] = bitval[2] >> 1;
+  bitval[0] = bitval[1] >> 1;
+}
+
+//select reasonable dividers for a frequency
+//in order to avoid overflow, the frequency is scaled by 10
+void Si570::setDividers (unsigned long f){
+  unsigned int i, j;
+  unsigned long f_dco;
+
+  for (i = 2; i <= 127; i+= 2) {
+    for (j = 4; j <= 11; j++){
+      //skip 8 and 10 as unused
+      if (j == 8 || j == 10)
+        continue;
+      f_dco = (f/10) * i * j;
+      if (480000000L < f_dco && f_dco < 560000000L){
+        if (hs != j || n1 != i){
+          hs = j; n1 = i;
+          setBitvals();
+        }
+        //f_dco = fnew/10 * n1 * hs;
+        return;
+      }
+    }
+  }
+}
+
+void Si570::setRfreq (unsigned long fnew){
+  int i, bit, ireg, byte;
+  unsigned long rfreq;
+
+  //reset all the registers
+  for (i = 7; i <= 12; i++)
+    this->dco_reg[i] = 0;
+
+  //set up HS
+  this->dco_reg[7] = (hs - 4) << 5;
+  this->dco_reg[7] = this->dco_reg[7] | ((n1 - 1) >> 2);
+  this->dco_reg[8] = ((n1-1) & 0x3) << 6;
+
+  ireg = 8; //registers go from 8 to 12 (five of them)
+  bit = 5; //the bits keep walking down
+  byte = 0;
+  rfreq = 0;
+  for (i = 37; i >= 0; i--){
+    //skip if the bitvalue is set to zero, it means, we have hit the bottom of the bitval table
+    if (bitval[i] == 0)
+      break;
+
+    if (fnew >= bitval[i]){
+      fnew = fnew - bitval[i];
+      byte = byte | (1 << bit);
+    }
+    //else{
+    // putchar('0');
+    //}
+
+    bit--;
+    if (bit < 0){
+      bit = 7;
+      //use OR instead of = as register[7] has N1 bits already set into it
+      this->dco_reg[ireg] |= byte;
+      byte = 0;
+      ireg++;
+    }
+  }
+}
+
+Si570_Status Si570::setFrequency(unsigned long newfreq) {
+  //check that we are not wasting our time here
+  if (this->frequency == newfreq)
+    return this->status;
+
+  //if the jump is small enough, we don't have to fiddle with the dividers
+  if (abs(this->f_center - newfreq) < 50000L) {
+    setRfreq(newfreq);
+    this->frequency = newfreq;
+    qwrite_si570();
+    this->status = SUCCESS_SMALLJUMP;
+  }
+  else {
+    //else it is a big jump
+    setDividers(newfreq);
+    setRfreq(newfreq);
+    this->f_center = this->frequency = newfreq;
+    write_si570();
+    this->status = SUCCESS_BIGJUMP;
+  }
+  return this->status;
+}

--- a/Si570.h
+++ b/Si570.h
@@ -1,0 +1,34 @@
+typedef enum {
+  SUCCESS_BIGJUMP = 0,
+  SUCCESS_SMALLJUMP
+} Si570_Status;
+
+class Si570
+{
+public:
+  Si570(char i2c_address);
+
+  Si570_Status setFrequency(unsigned long newfreq);
+
+  Si570_Status status;
+
+private:
+  char i2c_address;
+  unsigned char dco_reg[13];
+  unsigned long bitval[38];
+  unsigned long f_center;
+  unsigned long frequency;
+  unsigned int hs, n1;
+  unsigned long freq_xtal;
+
+  char i2c_read(int reg_address);
+  void i2c_write(char reg_address, char data);
+
+  void read_si570();
+  void write_si570();
+  void qwrite_si570();
+
+  void setRfreq(unsigned long fnew);
+  void setDividers (unsigned long f);
+  void setBitvals(void);
+};

--- a/Si570.h
+++ b/Si570.h
@@ -1,32 +1,42 @@
 typedef enum {
-  SUCCESS_BIGJUMP = 0,
-  SUCCESS_SMALLJUMP
+  SI570_ERROR = 0,
+  SI570_READY,
+  SI570_SUCCESS_BIGJUMP,
+  SI570_SUCCESS_SMALLJUMP
 } Si570_Status;
 
 class Si570
 {
 public:
-  Si570(char i2c_address);
-
+  Si570(uint8_t i2c_address, uint32_t calibration_frequency);
   Si570_Status setFrequency(unsigned long newfreq);
+  void debugSi570();
 
   Si570_Status status;
 
 private:
-  char i2c_address;
-  unsigned char dco_reg[13];
+  uint8_t i2c_address;
+  uint8_t dco_reg[13];
   unsigned long bitval[38];
   unsigned long f_center;
   unsigned long frequency;
   unsigned int hs, n1;
   unsigned long freq_xtal;
 
-  char i2c_read(int reg_address);
-  void i2c_write(char reg_address, char data);
+  uint8_t i2c_read(uint8_t reg_address);
+  int i2c_read(uint8_t reg_address, uint8_t *output, uint8_t length);
 
-  void read_si570();
+  void i2c_write(uint8_t reg_address, uint8_t data);
+  int i2c_write(uint8_t reg_address, uint8_t *data, uint8_t length);
+
+  bool read_si570();
   void write_si570();
   void qwrite_si570();
+
+  uint8_t getHsDiv();
+  uint8_t getN1();
+  uint64_t getRfReq();
+  double getRfReqDouble();
 
   void setRfreq(unsigned long fnew);
   void setDividers (unsigned long f);

--- a/radiono.ino
+++ b/radiono.ino
@@ -1,8 +1,22 @@
-#include <LiquidCrystal.h>
-#include "Wire.h"
-#include <avr/io.h> 
-#include <stdlib.h> 
+/*
+ * Minima main sketch
+ *
+ * FIXME: License?
+ *
+ * Copyright 2013 - Ashar Farhan
+ */
 
+
+#include <LiquidCrystal.h>
+/*
+ * Wire is only used from the Si570 module but we need to list it here so that
+ * the Arduino environment knows we need it.
+ */
+#include <Wire.h>
+
+#include <avr/io.h>
+#include <stdlib.h>
+#include "Si570.h"
 
 /*
  The 16x2 LCD is connected as follows:
@@ -12,32 +26,16 @@
     11          10             D4           17
     12          11             D5           16
     13           9             D6           15
-    14           8             D7           14 
-   
+    14           8             D7           14
 */
 
-/* si570 registers and stuff */
-//#define FREQ_XTAL (114 278 453) // my si570's crystal was at 114.78453 MHz
-//#define FREQ_XTAL (114 228 153L)
-
-//lvds
-//#define FREQ_XTAL (114285267)
-//cmos si570
-//#define FREQ_XTAL (1142121701) 
-
-#define FREQ_XTAL (114292532l)
+#define SI570_I2C_ADDRESS 0x55
 #define IF_FREQ   (19997000l) //this is for usb, we should probably have the USB and LSB frequencies separately
 #define CW_TIMEOUT (600l) // in milliseconds, this is the parameter that determines how long the tx will hold between cw key downs
 
-unsigned char si570_i2c_address = 0x55;
-unsigned char dco_reg[13], dco_status='s';
-unsigned long bitval[38];
-unsigned long f_center=0, frequency=14200000, dco_freq=0;
-unsigned int hs, n1;
+unsigned long frequency = 14200000;
 unsigned long vfoA=14200000L, vfoB=14200000L, ritA, ritB;
-unsigned char wasSmall = 1;
 unsigned long cwTimeout = 0;
-
 
 LiquidCrystal lcd(13, 12, 11, 10, 9, 8);
 int count = 0;
@@ -57,13 +55,15 @@ unsigned char locked = 0; //the tuning can be locked: wait until it goes into de
 
 #define BAND_HI (5)
 
-#define FBUTTON (A3) 
+#define FBUTTON (A3)
 #define ANALOG_TUNING (A2)
 #define ANALOG_KEYER (A1)
 
 
 #define VFO_A 0
 #define VFO_B 1
+
+Si570 *dco;
 
 char inTx = 0;
 char keyDown = 0;
@@ -94,7 +94,7 @@ void printLine2(char *c){
 
 void displayFrequency(unsigned long f){
   int mhz, khz, hz;
-  
+
   mhz = f / 1000000l;
   khz = (f % 1000000l)/1000;
   hz = f % 1000l;
@@ -103,239 +103,37 @@ void displayFrequency(unsigned long f){
 }
 
 void updateDisplay(){
-    sprintf(b, "%08ld", frequency);      
-    sprintf(c, "%s:%.2s.%.4s %s", vfoActive == VFO_A ? " A" : " B" , b,  b+2, ritOn ? "+RX" : "   ");       
+    sprintf(b, "%08ld", frequency);
+    sprintf(c, "%s:%.2s.%.4s %s", vfoActive == VFO_A ? " A" : " B" , b,  b+2, ritOn ? "+RX" : "   ");
     printLine1(c);
-    sprintf(c, "%s %s %d", isLSB ? "LSB" : "USB", inTx ? " TX" : " RX",  wasSmall);
+    sprintf(c, "%s %s %d", isLSB ? "LSB" : "USB", inTx ? " TX" : " RX", dco->status);
     printLine2(c);
 }
 
 
-/* 
-IMPORTANT, the wire.h is modified so that the internal pull up resisters are not enabled. 
-This is required to interface Arduino with the 3.3v Si570's I2C interface.
-routines to interface with si570 via i2c (clock on analog pin 5, data on analog pin 4) */
 
-void i2c_write (char slave_address,char reg_address, char data )  {
-  int rdata = data;
-  Wire.beginTransmission(slave_address);
-  Wire.write(reg_address);
-  Wire.write(rdata);
-  Wire.endTransmission();
-}
-
-char i2c_read ( char slave_address, int reg_address ) {
-  unsigned char rdata = 0xFF;
-  Wire.beginTransmission(slave_address);
-  Wire.write(reg_address);
-  Wire.endTransmission();
-  Wire.requestFrom(slave_address,1);
-  if (Wire.available()) rdata = Wire.read();
-  return rdata;
-}
-
-void read_si570(){
-  //we have to read eight consecutive registers starting at register 5
-  for (int i = 7; i <= 12; i++) 
-    dco_reg[i] = i2c_read( si570_i2c_address, i);
-}
-
-void write_si570()
-{
-  int idco, i;
-  
-  // Freeze DCO
-  idco = i2c_read( si570_i2c_address,137);
-  i2c_write(si570_i2c_address, 137, idco | 0x10 );
-  	
-  i2c_write(si570_i2c_address, 7, dco_reg[7]);
-  
-  //Set Registers
-  for( i=7; i <= 12; i++){
-    i2c_write(si570_i2c_address, i, dco_reg[i]);
-    idco = i2c_read( si570_i2c_address, i);
-  }
-
-  // Unfreeze DCO
-  idco = i2c_read( si570_i2c_address, 137 );
-  i2c_write (si570_i2c_address, 137, idco & 0xEF );
-  
-  // Set new freq
-  i2c_write(si570_i2c_address,135,0x40);        
-}
-
-void qwrite_si570()
-{   
-  int i, idco;
-  //Set Registers
-  for( i=8; i <= 12; i++){
-    i2c_write(si570_i2c_address, i, dco_reg[i]);
-    idco = i2c_read( si570_i2c_address, i);
-  }
-}
-
-void setBitvals(void){
-
-	//set the rfreq values for each bit of the rfreq (integral)
-	bitval[28] = (FREQ_XTAL) / (hs * n1);
-	bitval[29] = bitval[28] << 1;
-	bitval[30] = bitval[29] << 1;
-	bitval[31] = bitval[30] << 1;
-	bitval[32] = bitval[31] << 1;
-	bitval[33] = bitval[32] << 1;
-	bitval[34] = bitval[33] << 1;
-	bitval[35] = bitval[34] << 1;
-	bitval[36] = bitval[35] << 1;
-	bitval[37] = bitval[36] << 1;
-
-	//set the rfreq values for each bit of the rfreq (integral)
-	bitval[27] = bitval[28] >> 1;
-	bitval[26] = bitval[27] >> 1;
-	bitval[25] = bitval[26] >> 1;
-	bitval[24] = bitval[25] >> 1;
-	bitval[23] = bitval[24] >> 1;
-	bitval[22] = bitval[23] >> 1;
-	bitval[21] = bitval[22] >> 1;
-	bitval[20] = bitval[21] >> 1;
-	bitval[19] = bitval[20] >> 1;
-	bitval[18] = bitval[19] >> 1;
-	bitval[17] = bitval[18] >> 1;
-	bitval[16] = bitval[17] >> 1;
-	bitval[15] = bitval[16] >> 1;
-	bitval[14] = bitval[15] >> 1;
-	bitval[13] = bitval[14] >> 1;
-	bitval[12] = bitval[13] >> 1;
-	bitval[11] = bitval[12] >> 1;
-	bitval[10] = bitval[11] >> 1;
-	bitval[9] = bitval[10] >> 1;
-	bitval[8] = bitval[9] >> 1;
-	bitval[7] = bitval[8] >> 1;
-	bitval[6] = bitval[7] >> 1;
-	bitval[5] = bitval[6] >> 1;
-	bitval[4] = bitval[5] >> 1;
-	bitval[3] = bitval[4] >> 1;
-	bitval[2] = bitval[3] >> 1;
-	bitval[1] = bitval[2] >> 1;
-	bitval[0] = bitval[1] >> 1;
-}
-
-//select reasonable dividers for a frequency
-//in order to avoid overflow, the frequency is scaled by 10
-void setDividers (unsigned long f){
-  int i, j;
-  unsigned long f_dco;
-  
-  for (i = 2; i <= 127; i+= 2)
-    for (j = 4; j <= 11; j++){
-      //skip 8 and 10 as unused
-      if (j == 8 || j == 10)
-        continue;
-      f_dco = (f/10) * i * j;
-      if (480000000L < f_dco && f_dco < 560000000L){
-        if (hs != j || n1 != i){
-          hs = j; n1 = i;
-	  setBitvals();
-        }
-        //f_dco = fnew/10 * n1 * hs;
-        return;
-    }
-  }
-}
-
-void setRfreq (unsigned long fnew){
-  int i, bit, ireg, byte;
-  unsigned long rfreq;
-
-  //reset all the registers
-  for (i = 7; i <= 12; i++)
-    dco_reg[i] = 0;
-
-  //set up HS
-  dco_reg[7] = (hs - 4) << 5;
-  dco_reg[7] = dco_reg[7] | ((n1 - 1) >> 2);
-  dco_reg[8] = ((n1-1) & 0x3) << 6;
-
-  ireg = 8; //registers go from 8 to 12 (five of them)
-  bit = 5; //the bits keep walking down
-  byte = 0;
-  rfreq = 0;
-  for (i = 37; i >= 0; i--){
-    //skip if the bitvalue is set to zero, it means, we have hit the bottom of the bitval table
-    if (bitval[i] == 0)
-      break;
-
-    if (fnew >= bitval[i]){
-      fnew = fnew - bitval[i];
-      byte = byte | (1 << bit);
-    }
-    //else{
-    // putchar('0');
-    //}
-
-    bit--;
-    if (bit < 0){
-      bit = 7;
-      //use OR instead of = as register[7] has N1 bits already set into it
-      dco_reg[ireg] |= byte;
-      byte = 0;
-      ireg++;
-    }
-  }
-}
-
-void setDCO(unsigned long newfreq){
-  
-  //check that we are not wasting our time here
-  if (dco_freq == newfreq)
-    return;
-  
-  //if the jump is small enough, we don't have to fiddle with the dividers
-  if ((newfreq > f_center && newfreq - f_center < 50000L) ||
-    (f_center > newfreq && f_center - newfreq < 50000L)){
-    setRfreq(newfreq);
-    dco_freq = newfreq;
-    qwrite_si570();
-    wasSmall = 1;
-    return;
-  }
-  //else it is a big jump
-  setDividers(newfreq);
-  setRfreq(newfreq);
-  f_center = dco_freq = newfreq;
-  write_si570();
-  wasSmall = 0;
-}
-
-void setup() {                
+void setup() {
   lcd.begin(16, 2);
   printBuff[0] = 0;
-  printLine1("Raduino v0.02 "); 
+  printLine1("Raduino v0.02 ");
 
-  Wire.begin();
-  // Disable internal pullups
-  digitalWrite(SDA, 0);
-  digitalWrite(SCL, 0);
-
-  // Force Si570 to reset to initial freq
-  i2c_write(si570_i2c_address,135,0x01);
-  delay(20);
-  read_si570();
-
-
+  dco = new Si570(SI570_I2C_ADDRESS);
+  /*
   sprintf(c, "%02x %02x %02x ", dco_reg[7], dco_reg[8], dco_reg[9]);
   printLine1(c);
- 
+
   sprintf(c, "%02x %02x %02x ", dco_reg[10], dco_reg[11], dco_reg[12]);
   printLine2(c);
+  */
 
   //set the initial frequency
-  setDCO(26150000L);
+  dco->setFrequency(26150000L);
 
   //set up the pins
   pinMode(LSB, OUTPUT);
   pinMode(TX_RX, INPUT);
   pinMode(CW_KEY, OUTPUT);
-  
+
   //set the side-tone off, put the transceiver to receive mode
   digitalWrite(CW_KEY, 0);
   digitalWrite(TX_RX, 1); //old way to enable the built-in pull-ups
@@ -368,7 +166,7 @@ void readTuningPot(){
 }
 
 void checkTuning(){
-    
+
   if (-50 < tuningPosition && tuningPosition < 50){
     //we are in the middle, so, let go of the lock
     if (locked)
@@ -380,7 +178,7 @@ void checkTuning(){
   //if the tuning is locked and we are outside the safe band, then we don't move the freq.
   if (locked)
     return;
-    
+
   //dead region between -50 and 50
   if (100 < tuningPosition){
     if (tuningPosition < 100)
@@ -396,14 +194,14 @@ void checkTuning(){
     else if (tuningPosition < 350)
       frequency += 1000;
     else if (tuningPosition < 400)
-      frequency += 3000;   
+      frequency += 3000;
     else if (tuningPosition < 450){
-      frequency += 100000;   
+      frequency += 100000;
       updateDisplay();
       delay(300);
     }
     else if (tuningPosition < 500){
-      frequency += 1000000;   
+      frequency += 1000000;
       updateDisplay();
       delay(300);
     }
@@ -423,41 +221,41 @@ void checkTuning(){
     else if (tuningPosition > -350)
       frequency -= 1000;
     else if (tuningPosition > -400)
-      frequency -= 3000;   
+      frequency -= 3000;
     else if (tuningPosition > -450){
-      frequency -= 100000;   
+      frequency -= 100000;
       updateDisplay();
       delay(300);
     }
     else if (tuningPosition > -500){
-      frequency -= 1000000;   
+      frequency -= 1000000;
       updateDisplay();
       delay(300);
     }
   }
-  delay(50);  
+  delay(50);
   refreshDisplay++;
 }
 
 
 void checkTX(){
-	
+
   //we don't check for ptt when transmitting cw
   if (cwTimeout > 0)
     return;
-    
+
   if (digitalRead(TX_RX) == 0 && inTx == 0){
     refreshDisplay++;
     inTx = 1;
   }
-	
+
   if (digitalRead(TX_RX) == 1 && inTx == 1){
     refreshDisplay++;
     inTx = 0;
   }
 }
 
- 
+
 /*CW is generated by keying the bias of a side-tone oscillator.
 nonzero cwTimeout denotes that we are in cw transmit mode.
 */
@@ -483,14 +281,14 @@ void checkCW(){
   if (keyDown == 1){
      cwTimeout = CW_TIMEOUT + millis();
   }
-  
+
   //if we have a keyup
   if (keyDown == 1 && analogRead(ANALOG_KEYER) > 150){
     keyDown = 0;
     digitalWrite(CW_KEY, 0);
     cwTimeout = millis() + CW_TIMEOUT;
   }
-  
+
   //if we have keyuup for a longish time while in cw tx mode
   if (inTx == 1 && cwTimeout < millis()){
     //move the radio back to receive
@@ -527,19 +325,19 @@ void checkButton(){
     delay(200);
     return;
   }
-  
+
   t1 = t2 = i = 0;
 
   while (t1 < 30 && btnDown() == 1){
     delay(50);
     t1++;
   }
-   
+
   while (t2 < 10 && btnDown() == 0){
     delay(50);
     t2++;
   }
-  
+
   //if the press is momentary and there is no secondary press
   if (t1 < 10 && t2 > 6){
     if (ritOn)
@@ -563,7 +361,7 @@ void checkButton(){
     }
      refreshDisplay++;
      printLine2("VFO swap! ");
-  } 
+  }
   else if (t1 > 10){
     printLine2("VFOs reset!");
     vfoA= vfoB = frequency;
@@ -572,7 +370,7 @@ void checkButton(){
 
 //  sprintf(c, "t1=%d, t2=%d ", t1, t2);
 //  printLine2(c);
-  
+
   while (btnDown() == 1){
      delay(50);
   }
@@ -589,14 +387,15 @@ void loop(){
   checkTX();
   checkButton();
 
-  setDCO(frequency+ IF_FREQ);
-  setSideband();  
+  dco->setFrequency(frequency + IF_FREQ);
+
+  setSideband();
   setBandswitch();
-  
+
   if (refreshDisplay){
     updateDisplay();
     refreshDisplay = 0;
 //    delay(10);
-  }  
+  }
 }
 

--- a/radiono.ino
+++ b/radiono.ino
@@ -1,6 +1,4 @@
 #include <LiquidCrystal.h>
-#include <Boards.h>
-#include <Firmata.h>
 #include "Wire.h"
 #include <avr/io.h> 
 #include <stdlib.h> 

--- a/radiono.ino
+++ b/radiono.ino
@@ -314,6 +314,9 @@ void setup() {
   printLine1("Raduino v0.02 "); 
 
   Wire.begin();
+  // Disable internal pullups
+  digitalWrite(SDA, 0);
+  digitalWrite(SCL, 0);
 
   // Force Si570 to reset to initial freq
   i2c_write(si570_i2c_address,135,0x01);


### PR DESCRIPTION
I have split the Si570 code in a separate class and done the following changes:

In the Si570 class:
- Use the factory-calibrated output frequency to automatically calculate the internal
  crystal frequency and use that instead of hard coded values.
- During initialization detect errors talking to the Si570.
- Use multi-bytes i2c reads and writes when possible (ie: read/write multiple bytes
  without re-starting a transaction). Only works for read/writes in consecutive registers.
- Use types with explicit size where that makes sense (uint8_t instead of char, uint64_t, etc)
- Added some debugging on the serial console through a "debug" function

In the main sketch:
- Show a message on the LCD if the Si570 is unreachable.
- Initialize the serial port for debugging
- Fix some compilation warnings with string litterals being casted to char*
- Removed unused variables
