### PR TITLE
Fix si570 stuck bug

### DIFF
--- a/Si570.cpp
+++ b/Si570.cpp
@@ -56,7 +56,7 @@ void Si570::debugSi570() {
   debug(" --- Si570 Debug Info ---");
   debug("Crystal frequency calibrated at: %lu", freq_xtal);
   debug("Status: %i", status);
-  for (int i = 7; i < 15; i++) {
+  for (int i = 7; i < 13; i++) {
     debug("Register[%i] = %02x", i, dco_reg[i]);
   }
   debug("HsDivider = %i  N1 = %i", getHsDiv(), getN1());
@@ -149,7 +149,7 @@ int Si570::i2c_read(uint8_t reg_address, uint8_t *output, uint8_t length) {
 bool Si570::read_si570(){
   // Try 3 times to read the registers
   for (int i = 0; i < 3; i++) {
-    //we have to read eight consecutive registers starting at register 7
+    //we have to read six consecutive registers starting at register 7
     if (i2c_read(7, &(dco_reg[7]), 6) == 6) {
       return true;
     }

--- a/Si570.cpp
+++ b/Si570.cpp
@@ -132,7 +132,7 @@ int Si570::i2c_read(uint8_t reg_address, uint8_t *output, uint8_t length) {
 
   int error = Wire.endTransmission();
   if (error != 0) {
-    debug("Error reading %i bytes from register %i. endTransmission() returned %i", reg_address, error);
+    debug("Error reading %i bytes from register %i. endTransmission() returned %i", length, reg_address, error);
     return 0;
   }
 

--- a/Si570.cpp
+++ b/Si570.cpp
@@ -11,7 +11,7 @@
 #include <Wire.h>
 
 #include "Si570.h"
-#include "util.h"
+#include "debug.h"
 
 Si570::Si570(uint8_t si570_address, uint32_t calibration_frequency) {
   i2c_address = si570_address;

--- a/Si570.cpp
+++ b/Si570.cpp
@@ -88,7 +88,6 @@ uint8_t Si570::getN1() {
 uint64_t Si570::getRfReq() {
   uint64_t dcoFrequency = 0;
 
-  dcoFrequency = 0;
   dcoFrequency = (uint64_t)(dco_reg[8] & 0x3F);
   dcoFrequency = (dcoFrequency << 8) | (uint64_t) dco_reg[9];
   dcoFrequency = (dcoFrequency << 8) | (uint64_t) dco_reg[10];

--- a/Si570.h
+++ b/Si570.h
@@ -8,8 +8,13 @@ typedef enum {
 class Si570
 {
 public:
+  /* Will initialize from the give i2c_address */
   Si570(uint8_t i2c_address, uint32_t calibration_frequency);
+  /* Manually initialize with those register values -- For testing only. */
+  Si570(uint8_t registers[], uint32_t calibration_frequency);
+
   Si570_Status setFrequency(unsigned long newfreq);
+  unsigned long getFreqXtal();
   void debugSi570();
 
   Si570_Status status;

--- a/debug.cpp
+++ b/debug.cpp
@@ -1,0 +1,14 @@
+
+#include <Arduino.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "util.h"
+
+void debug(char const *fmt, ... ) {
+  char tmp[128]; // resulting string limited to 128 chars
+  va_list args;
+  va_start (args, fmt );
+  vsnprintf(tmp, sizeof(tmp), fmt, args);
+  va_end (args);
+  Serial.println(tmp);
+}

--- a/debug.cpp
+++ b/debug.cpp
@@ -2,7 +2,7 @@
 #include <Arduino.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include "util.h"
+#include "debug.h"
 
 void debug(char const *fmt, ... ) {
   char tmp[128]; // resulting string limited to 128 chars

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,2 @@
+
+void debug(char const *fmt, ... );


### PR DESCRIPTION
Fixes the Si570 bug reported by Jerry and Mac on the mailing list.

We would fail to properly read the factory calibrated dco_frequency if the register[11] had the most significant bit set to one. I added two tests in the project. We can add more tests when we find new bugs and by keeping the history of tests, we can also make sure that we are not breaking anything in the future.
